### PR TITLE
Add Java assert feature

### DIFF
--- a/src/main/java/duke/command/DeadlineCommand.java
+++ b/src/main/java/duke/command/DeadlineCommand.java
@@ -19,6 +19,8 @@ public class DeadlineCommand extends Command {
         int slash = desc.lastIndexOf("/");
         this.by = desc.substring(slash + 4);
         this.desc = desc.substring(0, slash - 1);
+        assert !this.desc.isEmpty() : "task description cannot be empty";
+        assert !this.by.isEmpty() : "deadline cannot be empty";
     }
 
     @Override

--- a/src/main/java/duke/command/DeleteCommand.java
+++ b/src/main/java/duke/command/DeleteCommand.java
@@ -13,6 +13,7 @@ public class DeleteCommand extends Command {
 
     public DeleteCommand(String desc) {
         numberOnly = desc.replaceAll("[^0-9]", "");
+        assert !numberOnly.isEmpty() : "index of task to be deleted cannot be empty";
     }
 
     @Override

--- a/src/main/java/duke/command/EventCommand.java
+++ b/src/main/java/duke/command/EventCommand.java
@@ -17,6 +17,8 @@ public class EventCommand extends Command {
         int slash = desc.lastIndexOf("/");
         this.at = desc.substring(slash + 4);
         this.desc = desc.substring(0, slash - 1);
+        assert !this.desc.isEmpty() : "task description cannot be empty";
+        assert !this.at.isEmpty() : "event date cannot be empty";
     }
 
     @Override

--- a/src/main/java/duke/command/FindCommand.java
+++ b/src/main/java/duke/command/FindCommand.java
@@ -14,6 +14,7 @@ public class FindCommand extends Command {
     public FindCommand(String desc) {
         desc = desc.replace("find ", "");
         this.desc = desc;
+        assert !desc.isEmpty() : "search description cannot be empty";
     }
 
     @Override
@@ -27,6 +28,7 @@ public class FindCommand extends Command {
         int qty = 0;
         String output = "Here are the matching tasks I've found:";
         while (iterate.hasNext()) {
+            assert qty >= 0 : "qty cannot be less than zero";
             Task currentTask = iterate.next();
             if (currentTask.getDesc().contains(desc)) {
                 qty++;

--- a/src/main/java/duke/command/ListCommand.java
+++ b/src/main/java/duke/command/ListCommand.java
@@ -15,6 +15,7 @@ public class ListCommand extends Command {
         String output = "Here are the tasks you currently have: \n";
         int qty = 0;
         while (iterate.hasNext()) {
+            assert qty >= 0 : "qty cannot be less than zero";
             qty++;
             output += qty + "." + iterate.next().toString() + "\n";
         }

--- a/src/main/java/duke/command/MarkCommand.java
+++ b/src/main/java/duke/command/MarkCommand.java
@@ -12,6 +12,7 @@ public class MarkCommand extends Command {
 
     public MarkCommand(String desc) {
         String numberOnly = desc.replaceAll("[^0-9]", "");
+        assert !numberOnly.isEmpty() : "index of task cannot be empty";
         index = Integer.parseInt(numberOnly);
     }
 

--- a/src/main/java/duke/command/ToDoCommand.java
+++ b/src/main/java/duke/command/ToDoCommand.java
@@ -13,6 +13,7 @@ public class ToDoCommand extends Command {
 
     public ToDoCommand(String desc) {
         this.desc = desc.replace("todo", "");
+        assert !this.desc.isEmpty() : "task description cannot be empty";
     }
 
     @Override

--- a/src/main/java/duke/command/UnmarkCommand.java
+++ b/src/main/java/duke/command/UnmarkCommand.java
@@ -12,6 +12,7 @@ public class UnmarkCommand extends Command {
 
     public UnmarkCommand(String desc) {
         String numberOnly = desc.replaceAll("[^0-9]", "");
+        assert !numberOnly.isEmpty() : "index of task cannot be empty";
         index = Integer.parseInt(numberOnly);
     }
 


### PR DESCRIPTION
Integer variables used as counters, in some classes that inherit from Command, cannot be less than zero.
In some classes that inherit from Command, the task description and/or the date cannot be empty.

So let's assume that these are not the case in the code. If the cases which they do happen, we let the runtime detect an assertion failure to inform us that there are potentially bugs that cause it to happen.